### PR TITLE
Allow interactive sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,25 @@ let niterations = 100;
 sampler.run_mcmc(&perturbed_guess, niterations).expect("error running sampler");
 ```
 
+#### Iterative sampling
+
+It is sometimes useful to get the internal values proposed and evaluated
+during each proposal step of the sampler. In the Python version, the
+method `sample` is a generator which can be iterated over to evaluate
+the sample steps.
+
+In this Rust version, we provide this feature by exposing the
+[`sample`][emcee-sample] method, which takes a callback, which is called
+once per iteration with a single [`Step`][emcee-step] object. For
+example:
+
+```rust
+sampler.sample(&perturbed_guess, niterations, |step| {
+    println!("Current guess vectors: {:?}", step.pos);
+    println!("Current log posterior probabilities: {:?}", step.lnprob);
+});
+```
+
 ### Studying the results
 
 The samples are stored in the sampler's `flatchain` which is constructed through the
@@ -151,14 +170,16 @@ for (i, guess) in flatchain.iter().enumerate() {
 ```
 
 [emcee]: http://dan.iel.fm/emcee/current/
-[emcee-prob]: prob/trait.Prob.html
-[emcee-guess]: guess/struct.Guess.html
-[emcee-lnprob]: prob/trait.Prob.html#method.lnprob
+[emcee-prob]: https://docs.rs/emcee/0.3.0/emcee/trait.Prob.html
+[emcee-guess]: https://docs.rs/emcee/0.3.0/emcee/struct.Guess.html
+[emcee-lnprob]: https://docs.rs/emcee/0.3.0/emcee/trait.Prob.html#method.lnprob
 [std-infinity]: https://doc.rust-lang.org/std/f32/constant.INFINITY.html
-[emcee-create-initial-guess]: guess/struct.Guess.html#method.create_initial_guess
-[emcee-flatchain]: struct.EnsembleSampler.html#method.flatchain
+[emcee-create-initial-guess]: https://docs.rs/emcee/0.3.0/emcee/struct.Guess.html#method.create_initial_guess
+[emcee-flatchain]: https://docs.rs/emcee/0.3.0/emcee/struct.EnsembleSampler.html#method.flatchain
 [docs]: https://docs.rs/emcee
 [fitting-model-to-data]: https://github.com/mindriot101/rust-emcee/blob/master/examples/fitting_a_model_to_data.rs
 [fitting-model-to-data-python]: http://dan.iel.fm/emcee/current/user/line/
 [dfm]: http://dan.iel.fm/
 [dfm-license]: https://github.com/mindriot101/rust-emcee/blob/master/DFM-LICENSE
+[emcee-sample]: https://docs.rs/emcee/0.3.0/emcee/struct.EnsembleSampler.html#method.sample
+[emcee-step]: https://docs.rs/emcee/0.3.0/emcee/struct.Step.html

--- a/src/guess.rs
+++ b/src/guess.rs
@@ -7,6 +7,7 @@ use rand::distributions::{Normal, IndependentSample};
 /// numbers, and are contained in a [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html).
 #[derive(Debug, Clone)]
 pub struct Guess {
+    /// A position in parameter space
     pub values: Vec<f32>,
 }
 
@@ -52,10 +53,12 @@ impl Guess {
             .collect()
     }
 
+    /// Returns if the guess vector contains infinite values
     pub fn contains_infs(&self) -> bool {
         self.values.iter().any(|val| val.is_infinite())
     }
 
+    /// Returns if the guess vector contains NaN values
     pub fn contains_nans(&self) -> bool {
         self.values.iter().any(|val| val.is_nan())
     }

--- a/src/prob.rs
+++ b/src/prob.rs
@@ -53,9 +53,13 @@ use guess::Guess;
 /// The default implementation of
 /// [`lnprob`](trait.Prob.html#method.lnprob) can be seen in the source code.
 pub trait Prob {
+    /// Computes the natural logarithm of the likelihood of a position in parameter space
     fn lnlike(&self, params: &Guess) -> f32;
+
+    /// Computes the natural logarithm of the prior probability of a position in parameter space
     fn lnprior(&self, params: &Guess) -> f32;
 
+    /// Computes the natural logarithm of the log posterior probabilities
     fn lnprob(&self, params: &Guess) -> f32 {
         let lnp = self.lnprior(params);
         if lnp.is_finite() {

--- a/src/stretch.rs
+++ b/src/stretch.rs
@@ -9,9 +9,9 @@ pub struct Stretch {
 }
 
 impl Stretch {
-    pub fn preallocated_accept(N: usize) -> Stretch {
+    pub fn preallocated_accept(size: usize) -> Stretch {
         let mut s = Stretch::default();
-        s.accept.resize(N, false);
+        s.accept.resize(size, false);
         s
     }
 }


### PR DESCRIPTION
The python library uses the `sample` method as a generator, allowing interaction with code outside of the sampler. We could implement this with a method that takes a callback, so the user can supply a closure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindriot101/rust-emcee/1)
<!-- Reviewable:end -->
