### PR TITLE
Remove error chain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ version = "0.3.0"
 repository = "mindriot101/rust-emcee"
 
 [dependencies]
-error-chain = "0.10.0"
 rand = "0.3.15"
 
 [dev-dependencies]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,44 @@
-error_chain! {
-    errors {
-        InvalidInputs(t: &'static str) {
-            description("invalid inputs")
-            display("invalid inputs: '{}'", t)
-        }
+//! Errors
+
+/// General error class for any errors possible from emcee
+#[derive(Debug)]
+pub enum EmceeError {
+    /// Encapsulates if invalid parameters are given when trying to create an EnsembleSampler
+    InvalidInputs(String),
+
+    /// General message type for ad-hoc messages
+    Msg(String),
+}
+
+impl ::std::fmt::Display for EmceeError {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "Emcee Error")
+    }
+}
+
+impl<'a> ::std::convert::From<&'a str> for EmceeError {
+    fn from(msg: &'a str) -> EmceeError {
+        EmceeError::Msg(msg.to_string())
+    }
+}
+
+/// Result alias which wraps [`EmceeError`][emcee-error]
+///
+/// [emcee-error]: https://example.com
+pub type Result<T> = ::std::result::Result<T, EmceeError>;
+
+impl ::std::error::Error for EmceeError {
+    fn description(&self) -> &str {
+        let details = match *self {
+            EmceeError::InvalidInputs(ref msg) => msg,
+            EmceeError::Msg(ref msg) => msg,
+        };
+        details.as_str()
+    }
+
+    fn cause(&self) -> Option<&::std::error::Error> {
+        // We are not wrapping other error types, and our types do not have an
+        // underlying cause beyond the description passed via the creation
+        None
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,13 +320,10 @@
 //! [emcee-sample]: struct.EnsembleSampler.html#method.sample
 //! [emcee-step]: struct.Step.html
 
-#![recursion_limit = "1024"]
 #![forbid(warnings)]
 #![warn(missing_docs)]
 
 extern crate rand;
-#[macro_use]
-extern crate error_chain;
 
 #[cfg(test)]
 #[macro_use]
@@ -396,13 +393,13 @@ impl<'a, T: Prob + 'a> EnsembleSampler<'a, T> {
     /// number of parameters
     pub fn new(nwalkers: usize, dim: usize, lnprob: &'a T) -> Result<Self> {
         if nwalkers % 2 != 0 {
-            return Err(ErrorKind::InvalidInputs("the number of walkers must be even").into());
+            return Err(EmceeError::InvalidInputs("the number of walkers must be even".into()));
         }
 
         if nwalkers <= 2 * dim {
             let msg = "the number of walkers should be more than \
                        twice the dimension of your parameter space";
-            return Err(ErrorKind::InvalidInputs(msg).into());
+            return Err(EmceeError::InvalidInputs(msg.into()));
         }
 
         Ok(EnsembleSampler {
@@ -837,13 +834,8 @@ mod tests {
         let (real_x, observed_y) = load_baked_dataset();
         let foo = LinearModel::new(&real_x, &observed_y);
         match EnsembleSampler::new(3, 3, &foo) {
-            Err(e) => {
-                match Error::from(e) {
-                    Error(ErrorKind::InvalidInputs(msg), _) => {
-                        assert!(msg.contains("number of walkers must be even"));
-                    }
-                    _ => panic!("incorrect"),
-                }
+            Err(EmceeError::InvalidInputs(msg)) => {
+                assert!(msg.contains("number of walkers must be even"));
             }
             _ => panic!("incorrect"),
         }
@@ -854,13 +846,8 @@ mod tests {
         let (real_x, observed_y) = load_baked_dataset();
         let foo = LinearModel::new(&real_x, &observed_y);
         match EnsembleSampler::new(4, 3, &foo) {
-            Err(e) => {
-                match Error::from(e) {
-                    Error(ErrorKind::InvalidInputs(msg), _) => {
-                        assert!(msg.contains("should be more than twice"));
-                    }
-                    _ => panic!("incorrect"),
-                }
+            Err(EmceeError::InvalidInputs(msg)) => {
+                assert!(msg.contains("should be more than twice"));
             }
             _ => panic!("incorrect"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,7 +329,7 @@ extern crate rand;
 #[macro_use]
 extern crate assert_approx_eq;
 
-mod errors;
+pub mod errors;
 mod guess;
 mod prob;
 mod stretch;


### PR DESCRIPTION
This makes compilation _much_ quicker, with no downside. We are only using a couple of error types, and so it is not too much boilerplate.

See #2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindriot101/rust-emcee/11)
<!-- Reviewable:end -->
