### PR TITLE
Make `EnsembleSampler.storechain` public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,7 +383,7 @@ pub struct EnsembleSampler<'a, T: Prob + 'a> {
     probstore: Option<ProbStore>,
     initial_state: Option<Step>,
 
-    /// Whether the sampler stores the chain; can be disabled in order to run large models  (default true)
+    /// Determines whether the sampler stores the chain; can be disabled in order to run large models (default true)
     pub storechain: bool,
 
     /// Thin the stored chains by this much, i.e. only every `thin`th step is stored (default 1)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,10 +383,10 @@ pub struct EnsembleSampler<'a, T: Prob + 'a> {
     probstore: Option<ProbStore>,
     initial_state: Option<Step>,
 
-    /// Allow disabling of storing the chain
-    storechain: bool,
+    /// Whether the sampler stores the chain; can be disabled in order to run large models  (default true)
+    pub storechain: bool,
 
-    /// Thin the stored chains by this much
+    /// Thin the stored chains by this much, i.e. only every `thin`th step is stored (default 1)
     pub thin: usize,
 }
 


### PR DESCRIPTION
Resolves #21.

All of the cargo tests still pass, and the use of the `storechain` variable was already covered by the test `EnsembleSampler::tests::test_not_storing_chain`.